### PR TITLE
CACHE_DOMAINS_REPO can now be set as an evironmental variable

### DIFF
--- a/overlay/scripts/bootstrap.sh
+++ b/overlay/scripts/bootstrap.sh
@@ -14,9 +14,9 @@ BANNER
 # Provide Defaults
 USE_GENERIC_CACHE="${USE_GENERIC_CACHE:-"false"}" #Using single IP for caching, which must be specified using LANCACHE.
 ENABLE_DNSSEC_VALIDATION="${ENABLE_DNSSEC_VALIDATION:-"false"}" #Enable DNS Security Validation
+CACHE_DOMAINS_REPO="${CACHE_DOMAINS_REPO:-"https://raw.githubusercontent.com/uklans/cache-domains/master/"}"
 
 # Static Entries
-CACHE_DOMAINS_REPO="https://raw.githubusercontent.com/uklans/cache-domains/master/"
 NAMED_OPTIONS="/etc/bind/named.conf.options"
 CACHE_CONF="/etc/bind/cache.conf"
 ZONEPATH="/etc/bind/cache/" #Location where the ${ServiceName}.db files will be kept.


### PR DESCRIPTION
Changed it so you can set the REPO as an environmental variable. Tested and works.